### PR TITLE
moved LFHCAL closer to FEMC

### DIFF
--- a/LFHcal/mapping/towerMap_LFHCAL_IP6-asymmetric-long.txt
+++ b/LFHcal/mapping/towerMap_LFHCAL_IP6-asymmetric-long.txt
@@ -7,7 +7,7 @@ Gr2_outer 262.1
 Gdz 140.1
 Gx0 0
 Gy0 0
-Gz0 420
+Gz0 404
 Grot_x 0
 Grot_y 0
 Grot_z 0

--- a/LFHcal/mapping/towerMap_LFHCAL_IP6-asymmetric.txt
+++ b/LFHcal/mapping/towerMap_LFHCAL_IP6-asymmetric.txt
@@ -7,7 +7,7 @@ Gr2_outer 262.1
 Gdz 100.1
 Gx0 0
 Gy0 0
-Gz0 400
+Gz0 384
 Grot_x 0
 Grot_y 0
 Grot_z 0

--- a/LFHcal/mapping/towerMap_LFHCAL_asymmetric-long.txt
+++ b/LFHcal/mapping/towerMap_LFHCAL_asymmetric-long.txt
@@ -7,7 +7,7 @@ Gr2_outer 262.1
 Gdz 140.1
 Gx0 0
 Gy0 0
-Gz0 420
+Gz0 404
 Grot_x 0
 Grot_y 0
 Grot_z 0

--- a/LFHcal/mapping/towerMap_LFHCAL_asymmetric.txt
+++ b/LFHcal/mapping/towerMap_LFHCAL_asymmetric.txt
@@ -7,7 +7,7 @@ Gr2_outer 262.1
 Gdz 100.1
 Gx0 0
 Gy0 0
-Gz0 400
+Gz0 384
 Grot_x 0
 Grot_y 0
 Grot_z 0


### PR DESCRIPTION
In order to retain space behind the LFHCAL for readout, it needs to be moved closer to FEMC, leaving a 6cm gap for the FEMC readout.